### PR TITLE
fix convertion of publishable assets

### DIFF
--- a/Converter.php
+++ b/Converter.php
@@ -75,7 +75,8 @@ class Converter extends \yii\web\AssetConverter
         }
 
         $parserConfig = ArrayHelper::merge($this->defaultParsersOptions[$ext], $this->parsers[$ext]);
-        $resultFile = $this->destinationDir . '/' . substr($asset, 0, $pos + 1) . $parserConfig['output'];
+        $resultFile = substr($asset, 0, $pos + 1)."compiled.". $parserConfig['output'];
+//        $resultFile = $this->destinationDir . '/' . substr($asset, 0, $pos + 1) . $parserConfig['output'];
 
         $from = $basePath . '/' . $asset;
         $to = $basePath .'/'. $resultFile;


### PR DESCRIPTION
1. Without conversion original AssetConverter::convert returns $asset without changes.
2. Conventional way to write $asset without starting "/".
3. If we place "/" before $resultFile, it will not be prepended with $baseUrl, which will cause the problem with publishable assets.
