### PR TITLE
Allow use without $destinationDir

### DIFF
--- a/Converter.php
+++ b/Converter.php
@@ -75,7 +75,9 @@ class Converter extends \yii\web\AssetConverter
         }
 
         $parserConfig = ArrayHelper::merge($this->defaultParsersOptions[$ext], $this->parsers[$ext]);
-        $resultFile = $this->destinationDir . '/' . substr($asset, 0, $pos + 1) . $parserConfig['output'];
+        if ($this->destinationDir)
+            $this->destinationDir .= '/';
+        $resultFile = $this->destinationDir . substr($asset, 0, $pos + 1) . $parserConfig['output'];
 
         $from = $basePath . '/' . $asset;
         $to = $basePath . '/' . $resultFile;


### PR DESCRIPTION
If you don't specify $destinationDir, you will get something like "webroot//css" (double slash).
This is a fix proposal.