### PR TITLE
Change the location of the Sass parser

### DIFF
--- a/Sass.php
+++ b/Sass.php
@@ -9,7 +9,7 @@ class Sass extends Parser
     /**
      * @var string to the class pointing to where sass parser is located.
      */
-    public $sassParserClass = '@app/extensions/assetparser/vendors/phamlp/sass/SassParser';
+    public $sassParserClass = '\SassParser';
 
     /**
      * @var string to the sass parser cache


### PR DESCRIPTION
Change value of property sassParserClass  to "\SassParser"
Was thrown an exception:
ReflectionException "Class @app/extensions/assetparser/vendors/phamlp/sass/SassParser does not exist in ~/vendor/yiisoft/yii2/di/Container.php at line 411"