### PR TITLE
Composer downloads very old 1.7.x-dev 8f77f13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.0",
         "yiisoft/yii2": "2.*",
         "yiisoft/yii2-composer": "2.*",
-        "oyejorge/less.php": "1.7.*",
+        "oyejorge/less.php": "dev-master",
         "richthegeek/phpsass": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Looks like "1.7.*" (as well as "~1.7", which I also tried on another fork) erroneously downloads very old 1.7.x-dev [8f77f13](https://github.com/oyejorge/less.php/commit/8f77f13bbc4d5997c76322523e1fb28376acf080). It leads to lots of errors as old version missed lots of fixes. That's not intended I guess.
This fix make it to download current dev version. That's not very good too (stable versions should be preferred), but it is affordable.
If someone could imagine a way to make it to work as desired - you're welcome.