### PR TITLE
Removed the repeated slashes from the result file

### DIFF
--- a/Converter.php
+++ b/Converter.php
@@ -75,12 +75,11 @@ class Converter extends \yii\web\AssetConverter
         }
 
         $parserConfig = ArrayHelper::merge($this->defaultParsersOptions[$ext], $this->parsers[$ext]);
-        if ($this->destinationDir) {
-            $this->destinationDir .= '/';
-	}
-        $resultFile = $this->destinationDir . substr($asset, 0, $pos + 1) . $parserConfig['output'];
 
-        $from = $basePath . '/' . $asset;
+        $this->destinationDir = $this->destinationDir ? trim($this->destinationDir, '/') : '';
+        $resultFile = $this->destinationDir . '/' . ltrim(substr($asset, 0, $pos + 1), '/') . $parserConfig['output'];
+
+        $from = $basePath . '/' . ltrim($asset, '/');
         $to = $basePath . '/' . $resultFile;
 
         if (!$this->needRecompile($from, $to)) {


### PR DESCRIPTION
For example, earlier was returned:
`/compiled//assets/bc9a2e00/checkbox.css`
`/compiled//css/admin-lte-custom.css`
`/compiled///css/site.css`