### PR TITLE
importDirs option for less compiler

### DIFF
--- a/Less.php
+++ b/Less.php
@@ -19,6 +19,9 @@ class Less extends Parser
     /** @var bool           If true, adjust urls to be relative, false means don't touch */
     public $relativeUrls    = true;
 
+    /** @var array           In this dirs less compiler find @import files */
+    public $importDirs      = [];    
+    
     /**
      * Set of variables to register and that will be available in the less files.
      * Note: The value should be in less format (strings are double quoted etc)
@@ -57,6 +60,7 @@ class Less extends Parser
 
         $less = new \lessc();
         $less->setVariables($variables);
+        $less->setImportDir(array_map(function($dir){ return Yii::getAlias($dir); }, $this->importDirs));
 
         // Compressed setting
         if ($this->compressed) {

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,7 @@ But you can change it by destinationDir property from config
                     'class' => 'nizsheanez\assetConverter\Less',
                     'output' => 'css', // parsed output file type
                     'options' => [
+		    	'importDirs' => [], // import paths, you may use path alias here ex. '@app/assets/common/less'
                         'auto' => true, // optional options
                     ]
                 ]


### PR DESCRIPTION
I added 'importDirs' option which can contains path aliases. In that directories less compiler can find files for @import directive.